### PR TITLE
Migrate workflow callers to ITensorActions v2

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,9 +1,11 @@
-name: "Check Compat Bounds"
+name: "CheckCompatBounds"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   check-compat-bounds:
-    name: "Check Compat Bounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
+    name: "CheckCompatBounds"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -7,9 +7,9 @@ permissions:
   contents: "write"
   pull-requests: "write"
 jobs:
-  compat-helper:
+  compathelper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,10 +10,12 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}"
+permissions:
+  contents: "write"
 jobs:
-  build-and-deploy-docs:
+  documentation:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v2"
     with:
       os: "ubuntu-22.04"
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,4 +1,4 @@
-name: "Format Check"
+name: "FormatCheck"
 on:
   pull_request:
     types:
@@ -6,7 +6,9 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+permissions:
+  contents: "read"
 jobs:
   format-check:
-    name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
+    name: "FormatCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v2"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,16 +1,19 @@
-name: "Format Check Comment"
+name: "FormatCheckComment"
 on:
   workflow_run:
     workflows:
-      - "Format Check"
+      - "FormatCheck"
     types:
       - "completed"
+permissions:
+  pull-requests: "write"
+  actions: "read"
 jobs:
-  comment:
-    name: "Format Check Comment"
+  format-check-comment:
+    name: "FormatCheckComment"
     if: "github.event.workflow_run.event == 'pull_request'"
     permissions:
       pull-requests: "write"
       actions: "read"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -1,4 +1,4 @@
-name: "Format Pull Request"
+name: "FormatPullRequest"
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -11,6 +11,6 @@ permissions:
   pull-requests: "write"
 jobs:
   format-pull-request:
-    name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
+    name: "FormatPullRequest"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,10 +11,13 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+permissions:
+  actions: "read"
+  contents: "read"
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -1,4 +1,4 @@
-name: "Integration Test Request"
+name: "IntegrationTestRequest"
 on:
   issue_comment:
     types:
@@ -9,11 +9,12 @@ permissions:
   checks: "write"
   pull-requests: "write"
 jobs:
-  integrationrequest:
+  integration-test-request:
+    name: "IntegrationTestRequest"
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -1,4 +1,4 @@
-name: "Register Package"
+name: "Registrator"
 on:
   workflow_dispatch: ~
   push:
@@ -15,8 +15,9 @@ permissions:
   pull-requests: "write"
   issues: "write"
 jobs:
-  Register:
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v1"
+  registrator:
+    name: "Registrator"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v2"
     with:
       localregistry: "ITensor/ITensorRegistry"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,8 +6,12 @@ on:
   workflow_dispatch: ~
 env:
   REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
+permissions:
+  contents: "write"
+  issues: "read"
 jobs:
-  TagBot:
+  tagbot:
+    name: "TagBot"
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,6 +19,8 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
+permissions:
+  contents: "read"
 jobs:
   tests:
     name: "Tests"
@@ -30,7 +32,7 @@ jobs:
           - "1"
         os:
           - "ubuntu-latest"
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -1,9 +1,12 @@
-name: "Version Check"
+name: "VersionCheck"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
+  pull-requests: "read"
 jobs:
   version-check:
-    name: "Version Check"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
+    name: "VersionCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"


### PR DESCRIPTION
## Summary

Manual application of the ecosystem-wide v2 sweep, with this repo's existing repo-specific inputs (xvfb, apt-packages, etc.) preserved. The standard `MassApplyPatch` sweep was applied to every other ecosystem repo, but skipped here because that patch overwrites caller workflow files entirely and would clobber the repo-specific reusable inputs needed for headless OpenGL CI.

## Changes

- Workflow top-level `name:` and primary inner-job display `name:` match the file's basename (e.g. `IntegrationTest.yml` → `name: "IntegrationTest"`).
- Job keys are kebab-case lowercase, with brand names (`tagbot`, `compathelper`) treated as single words.
- `uses: ITensor/ITensorActions/.../X.yml@v1` → `@v2`.
- `FormatCheckComment.yml` `workflow_run` trigger updated from `workflows: ["Format Check"]` to `["FormatCheck"]`.
- Explicit `permissions:` blocks added to every caller workflow that was missing one (matching the `ITensorPkgSkeleton` template shape).

## Preserved repo-specific inputs

The following remain unchanged:

- `Tests.yml` reusable inputs: `apt-packages`, `test-prefix`, `extra-env`, `upload-artifacts-path`. These set up xvfb + OpenGL packages so GLMakie tests can run headlessly on Linux.
- `Documentation.yml` reusable inputs: `apt-packages`, `doc-prefix`, plus the `os: "ubuntu-22.04"` runner pin.
- `Tests.yml` OS matrix restricted to `ubuntu-latest` only (macOS/Windows GitHub runners do not have working OpenGL drivers).

The `os: "ubuntu-22.04"` Documentation pin can probably be removed in a follow-up since v2 of the reusable fixes the `xvfb-run` shell-quoting regression that originally motivated it. Keeping the pin defensively for now.